### PR TITLE
Fixed validation for norwegian and belgian ibans

### DIFF
--- a/validators/iban.py
+++ b/validators/iban.py
@@ -3,7 +3,7 @@ import re
 from .utils import validator
 
 regex = (
-    r'^[A-Z]{2}[0-9]{2}[A-Z0-9]{13,30}$'
+    r'^[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}$'
 )
 pattern = re.compile(regex)
 


### PR DESCRIPTION
With the current implementation the regex didn't match for belgian and norwegian ibans. These are only 15 or 16 characters long (https://en.wikipedia.org/wiki/International_Bank_Account_Number#IBAN_formats_by_country).