### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'six>=1.4.0',
         'decorator>=3.4.0',
     ],
+    build_requires=install_requires,
     extras_require=extras_require,
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
added build_requires

I can't build pkg with "pyp2rpm validators" (in copr).
Exception occurred:   File "/builddir/build/BUILD/validators-0.11.0/validators/utils.py", line 5, in <module>
    import six
ImportError: No module named 'six'