### PR TITLE
Handle query strings in URLs without a path

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -15,6 +15,7 @@ from validators import url, ValidationFailure
     u'http://foo.com/blah_blah_(wikipedia)_(again)',
     u'http://www.example.com/wpstyle/?p=364',
     u'https://www.example.com/foo/?bar=baz&inga=42&quux',
+    u'https://www.example.com?bar=baz',
     u'http://✪df.ws/123',
     u'http://userid:password@example.com:8080',
     u'http://userid:password@example.com:8080/',

--- a/validators/url.py
+++ b/validators/url.py
@@ -40,6 +40,8 @@ regex = re.compile(
     u"(?::\d{2,5})?"
     # resource path
     u"(?:/\S*)?"
+    # query string
+    u"(?:\?\S*)?"
     u"$",
     re.UNICODE | re.IGNORECASE
 )


### PR DESCRIPTION
Simple of handling of URLs with a query string and no path, such as `https://www.example.com?bar=baz`. Previously such URLs were flagged as invalid.