### PR TITLE
Adding hash validators

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,6 +120,46 @@ mac_address
 .. autofunction:: mac_address
 
 
+md5
+-----------
+
+.. module:: validators.md5
+
+.. autofunction:: md5
+
+
+sha1
+-----------
+
+.. module:: validators.sha1
+
+.. autofunction:: sha1
+
+
+sha224
+-----------
+
+.. module:: validators.sha224
+
+.. autofunction:: sha224
+
+
+sha256
+-----------
+
+.. module:: validators.sha256
+
+.. autofunction:: sha256
+
+
+sha512
+-----------
+
+.. module:: validators.sha512
+
+.. autofunction:: sha512
+
+
 slug
 ----
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -123,7 +123,7 @@ mac_address
 md5
 -----------
 
-.. module:: validators.md5
+.. module:: validators.hashes
 
 .. autofunction:: md5
 
@@ -131,7 +131,7 @@ md5
 sha1
 -----------
 
-.. module:: validators.sha1
+.. module:: validators.hashes
 
 .. autofunction:: sha1
 
@@ -139,7 +139,7 @@ sha1
 sha224
 -----------
 
-.. module:: validators.sha224
+.. module:: validators.hashes
 
 .. autofunction:: sha224
 
@@ -147,7 +147,7 @@ sha224
 sha256
 -----------
 
-.. module:: validators.sha256
+.. module:: validators.hashes
 
 .. autofunction:: sha256
 
@@ -155,7 +155,7 @@ sha256
 sha512
 -----------
 
-.. module:: validators.sha512
+.. module:: validators.hashes
 
 .. autofunction:: sha512
 

--- a/tests/test_md5.py
+++ b/tests/test_md5.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import validators
+
+
+@pytest.mark.parametrize('value', [
+    'd41d8cd98f00b204e9800998ecf8427e',
+    'D41D8CD98F00B204E9800998ECF8427E'
+])
+def test_returns_true_on_valid_md5(value):
+    assert validators.md5(value)
+
+
+@pytest.mark.parametrize('value', [
+    'z41d8cd98f00b204e9800998ecf8427e',
+    'z8cd98f00b204e9800998ecf8427e',
+    'z4aaaa1d8cd98f00b204e9800998ecf8427e'
+])
+def test_returns_failed_validation_on_invalid_md5(value):
+    result = validators.md5(value)
+    assert isinstance(result, validators.ValidationFailure)

--- a/tests/test_sha1.py
+++ b/tests/test_sha1.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import validators
+
+
+@pytest.mark.parametrize('value', [
+    'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+    'DA39A3EE5E6B4B0D3255BFEF95601890AFD80709'
+])
+def test_returns_true_on_valid_sha1(value):
+    assert validators.sha1(value)
+
+
+@pytest.mark.parametrize('value', [
+    'za39a3ee5e6b4b0d3255bfef95601890afd80709',
+    'da39e5e6b4b0d3255bfef95601890afd80709',
+    'daaaa39a3ee5e6b4b0d3255bfef95601890afd80709'
+])
+def test_returns_failed_validation_on_invalid_sha1(value):
+    result = validators.sha1(value)
+    assert isinstance(result, validators.ValidationFailure)

--- a/tests/test_sha224.py
+++ b/tests/test_sha224.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import validators
+
+
+@pytest.mark.parametrize('value', [
+    'd14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f',
+    'D14A028C2A3A2BC9476102BB288234C415A2B01F828EA62AC5B3E42F'
+])
+def test_returns_true_on_valid_sha224(value):
+    assert validators.sha224(value)
+
+
+@pytest.mark.parametrize('value', [
+    'z14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f',
+    'd028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f',
+    'daaa14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f'
+])
+def test_returns_failed_validation_on_invalid_sha224(value):
+    result = validators.sha224(value)
+    assert isinstance(result, validators.ValidationFailure)

--- a/tests/test_sha256.py
+++ b/tests/test_sha256.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import validators
+
+
+@pytest.mark.parametrize('value', [
+    'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    'E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855'
+])
+def test_returns_true_on_valid_sha256(value):
+    assert validators.sha256(value)
+
+
+@pytest.mark.parametrize('value', [
+    'z3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    'ec44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    'eaaaa3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+])
+def test_returns_failed_validation_on_invalid_sha256(value):
+    result = validators.sha256(value)
+    assert isinstance(result, validators.ValidationFailure)

--- a/tests/test_sha512.py
+++ b/tests/test_sha512.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import validators
+
+
+@pytest.mark.parametrize('value', [
+    'cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e',
+    'CF83E1357EEFB8BDF1542850D66D8007D620E4050B5715DC83F4A921D36CE9CE47D0D13C5D85F2B0FF8318D2877EEC2F63B931BD47417A81A538327AF927DA3E'
+])
+def test_returns_true_on_valid_sha512(value):
+    assert validators.sha512(value)
+
+
+@pytest.mark.parametrize('value', [
+    'zf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e',
+    'cf8357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e',
+    'cf8aaaa3e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e'
+])
+def test_returns_failed_validation_on_invalid_sha512(value):
+    result = validators.sha512(value)
+    assert isinstance(result, validators.ValidationFailure)

--- a/validators/__init__.py
+++ b/validators/__init__.py
@@ -2,6 +2,7 @@ from .between import between  # noqa
 from .domain import domain  # noqa
 from .email import email  # noqa
 from .extremes import Max, Min  # noqa
+from .hashes import md5, sha1, sha224, sha256, sha512  # noqa
 from .i18n import fi_business_id, fi_ssn  # noqa
 from .iban import iban  # noqa
 from .ip_address import ipv4, ipv6  # noqa
@@ -12,6 +13,5 @@ from .truthy import truthy  # noqa
 from .url import url  # noqa
 from .utils import ValidationFailure, validator  # noqa
 from .uuid import uuid  # noqa
-from .hashs import md5, sha1, sha224, sha256, sha512  # noqa
 
 __version__ = '0.11.3'

--- a/validators/__init__.py
+++ b/validators/__init__.py
@@ -12,5 +12,6 @@ from .truthy import truthy  # noqa
 from .url import url  # noqa
 from .utils import ValidationFailure, validator  # noqa
 from .uuid import uuid  # noqa
+from .hashs import md5, sha1, sha224, sha256, sha512  # noqa
 
 __version__ = '0.11.3'

--- a/validators/hashes.py
+++ b/validators/hashes.py
@@ -30,7 +30,7 @@ def md5(value):
 
     Exemples::
 
-        >>> md5('da39a3ee5e6b4b0d3255bfef95601890afd80709')
+        >>> md5('d41d8cd98f00b204e9800998ecf8427e')
         True
 
         >>> md5('900zz11')
@@ -47,7 +47,7 @@ def sha1(value):
 
     Exemples::
 
-        >>> sha1('d41d8cd98f00b204e9800998ecf8427e')
+        >>> sha1('da39a3ee5e6b4b0d3255bfef95601890afd80709')
         True
 
         >>> sha1('900zz11')
@@ -81,7 +81,7 @@ def sha256(value):
 
     Exemples::
 
-        >>> sha256('d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f')
+        >>> sha256('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
         True
 
         >>> sha256('900zz11')

--- a/validators/hashes.py
+++ b/validators/hashes.py
@@ -23,6 +23,7 @@ sha512_regex = re.compile(
     re.IGNORECASE
 )
 
+
 @validator
 def md5(value):
     """
@@ -39,6 +40,7 @@ def md5(value):
     :param value: MD5 string to validate
     """
     return md5_regex.match(value)
+
 
 @validator
 def sha1(value):
@@ -57,6 +59,7 @@ def sha1(value):
     """
     return sha1_regex.match(value)
 
+
 @validator
 def sha224(value):
     """
@@ -74,6 +77,7 @@ def sha224(value):
     """
     return sha224_regex.match(value)
 
+
 @validator
 def sha256(value):
     """
@@ -90,6 +94,7 @@ def sha256(value):
     :param value: SHA256 string to validate
     """
     return sha256_regex.match(value)
+
 
 @validator
 def sha512(value):

--- a/validators/hashes.py
+++ b/validators/hashes.py
@@ -3,24 +3,24 @@ import re
 from .utils import validator
 
 md5_regex = re.compile(
-        r"^[0-9a-f]{32}$",
-        re.IGNORECASE
+    r"^[0-9a-f]{32}$",
+    re.IGNORECASE
 )
 sha1_regex = re.compile(
-        r"^[0-9a-f]{40}$",
-        re.IGNORECASE
+    r"^[0-9a-f]{40}$",
+    re.IGNORECASE
 )
 sha224_regex = re.compile(
-        r"^[0-9a-f]{56}$",
-        re.IGNORECASE
+    r"^[0-9a-f]{56}$",
+    re.IGNORECASE
 )
 sha256_regex = re.compile(
-        r"^[0-9a-f]{64}$",
-        re.IGNORECASE
+    r"^[0-9a-f]{64}$",
+    re.IGNORECASE
 )
 sha512_regex = re.compile(
-        r"^[0-9a-f]{128}$",
-        re.IGNORECASE
+    r"^[0-9a-f]{128}$",
+    re.IGNORECASE
 )
 
 @validator
@@ -30,7 +30,7 @@ def md5(value):
 
     Exemples::
 
-        >>> md5('d41d8cd98f00b204e9800998ecf8427e')
+        >>> md5('da39a3ee5e6b4b0d3255bfef95601890afd80709')
         True
 
         >>> md5('900zz11')
@@ -47,7 +47,7 @@ def sha1(value):
 
     Exemples::
 
-        >>> sha1('da39a3ee5e6b4b0d3255bfef95601890afd80709')
+        >>> sha1('d41d8cd98f00b204e9800998ecf8427e')
         True
 
         >>> sha1('900zz11')
@@ -81,7 +81,7 @@ def sha256(value):
 
     Exemples::
 
-        >>> sha256('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+        >>> sha256('d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f')
         True
 
         >>> sha256('900zz11')

--- a/validators/hashs.py
+++ b/validators/hashs.py
@@ -30,7 +30,7 @@ def md5(value):
 
     Exemples::
 
-        >>> md5('da39a3ee5e6b4b0d3255bfef95601890afd80709')
+        >>> md5('d41d8cd98f00b204e9800998ecf8427e')
         True
 
         >>> md5('900zz11')
@@ -47,7 +47,7 @@ def sha1(value):
 
     Exemples::
 
-        >>> sha1('d41d8cd98f00b204e9800998ecf8427e')
+        >>> sha1('da39a3ee5e6b4b0d3255bfef95601890afd80709')
         True
 
         >>> sha1('900zz11')
@@ -81,7 +81,7 @@ def sha256(value):
 
     Exemples::
 
-        >>> sha256('d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f')
+        >>> sha256('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
         True
 
         >>> sha256('900zz11')

--- a/validators/hashs.py
+++ b/validators/hashs.py
@@ -1,0 +1,109 @@
+import re
+
+from .utils import validator
+
+md5_regex = re.compile(
+        r"^[0-9a-f]{32}$",
+        re.IGNORECASE
+)
+sha1_regex = re.compile(
+        r"^[0-9a-f]{40}$",
+        re.IGNORECASE
+)
+sha224_regex = re.compile(
+        r"^[0-9a-f]{56}$",
+        re.IGNORECASE
+)
+sha256_regex = re.compile(
+        r"^[0-9a-f]{64}$",
+        re.IGNORECASE
+)
+sha512_regex = re.compile(
+        r"^[0-9a-f]{128}$",
+        re.IGNORECASE
+)
+
+@validator
+def md5(value):
+    """
+    Return whether or not given value is a valid MD5 hash.
+
+    Exemples::
+
+        >>> md5('da39a3ee5e6b4b0d3255bfef95601890afd80709')
+        True
+
+        >>> md5('900zz11')
+        ValidationFailure(func=md5, args={'value': '900zz11'})
+
+    :param value: MD5 string to validate
+    """
+    return md5_regex.match(value)
+
+@validator
+def sha1(value):
+    """
+    Return whether or not given value is a valid SHA1 hash.
+
+    Exemples::
+
+        >>> sha1('d41d8cd98f00b204e9800998ecf8427e')
+        True
+
+        >>> sha1('900zz11')
+        ValidationFailure(func=sha1, args={'value': '900zz11'})
+
+    :param value: SHA1 string to validate
+    """
+    return sha1_regex.match(value)
+
+@validator
+def sha224(value):
+    """
+    Return whether or not given value is a valid SHA224 hash.
+
+    Exemples::
+
+        >>> sha224('d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f')
+        True
+
+        >>> sha224('900zz11')
+        ValidationFailure(func=sha224, args={'value': '900zz11'})
+
+    :param value: SHA224 string to validate
+    """
+    return sha224_regex.match(value)
+
+@validator
+def sha256(value):
+    """
+    Return whether or not given value is a valid SHA256 hash.
+
+    Exemples::
+
+        >>> sha256('d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f')
+        True
+
+        >>> sha256('900zz11')
+        ValidationFailure(func=sha256, args={'value': '900zz11'})
+
+    :param value: SHA256 string to validate
+    """
+    return sha256_regex.match(value)
+
+@validator
+def sha512(value):
+    """
+    Return whether or not given value is a valid SHA512 hash.
+
+    Exemples::
+
+        >>> sha512('cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e')
+        True
+
+        >>> sha512('900zz11')
+        ValidationFailure(func=sha512, args={'value': '900zz11'})
+
+    :param value: SHA512 string to validate
+    """
+    return sha512_regex.match(value)


### PR DESCRIPTION
I was fed up of bad hashs validations on some scripts around. Here are validators for md5, sha1, sha224, sha256  and sha512.
Including tests and doc.

Each test include:
- valid : lowercase and uppercase hashs (of empty files)
- invalid : non-hex char, shorter, and longer size