### PR TITLE
IDNA encoded TLDs in domain validator were not covering all cases.

### DIFF
--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -9,7 +9,8 @@ from validators import domain, ValidationFailure
     'xn----gtbspbbmkef.xn--p1ai',
     'underscore_subdomain.example.com',
     'something.versicherung',
-    '11.com'
+    '11.com',
+    'somerandomwebsite.xn--fiqs8s'
 ])
 def test_returns_true_on_valid_domain(value):
     assert domain(value)

--- a/validators/domain.py
+++ b/validators/domain.py
@@ -3,10 +3,10 @@ import re
 from .utils import validator
 
 pattern = re.compile(
-    r'^(([a-zA-Z]{1})|([a-zA-Z]{1}[a-zA-Z]{1})|'
-    r'([a-zA-Z]{1}[0-9]{1})|([0-9]{1}[a-zA-Z]{1})|'
-    r'([a-zA-Z0-9][-_.a-zA-Z0-9]{0,61}[a-zA-Z0-9]))\.'
-    r'([a-zA-Z]{2,13}|[a-zA-Z0-9-]{2,30}.[a-zA-Z]{2,3})$'
+    r'^(([a-zA-Z]{1})|([a-zA-Z]{1}[a-zA-Z]{1})|'  # domain pt.1
+    r'([a-zA-Z]{1}[0-9]{1})|([0-9]{1}[a-zA-Z]{1})|'  # domain pt.2
+    r'([a-zA-Z0-9][-_.a-zA-Z0-9]{0,61}[a-zA-Z0-9]))\.'  # domain pt.3
+    r'([a-zA-Z]{2,13}|(xn--[a-zA-Z0-9]{2,30}))$'  # TLD
 )
 
 


### PR DESCRIPTION
Some specific correct domains where previously failing (like 'somerandomwebsite.xn--fiqs8s').

The validation pattern for the domain was changed so that it accepts two cases for TLDs:
 1) ASCII TLDs: accepts any a-z or A-Z characters from 2 till 13 reps (same as before)
 2) IDNA tlds: must start with 'xn--' (ACE prefix) and then any a-z, A-Z and 0-9 from 2 till 30 reps

New domain was added to the test which was previously failing