### PR TITLE
Fix IPv4 formatted IP address returning True on ipv6

### DIFF
--- a/tests/test_ipv4.py
+++ b/tests/test_ipv4.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from validators import ipv4, ValidationFailure
+from validators import ipv4, ipv6, ValidationFailure
 
 
 @pytest.mark.parametrize(('address',), [
@@ -11,6 +11,7 @@ from validators import ipv4, ValidationFailure
 ])
 def test_returns_true_on_valid_ipv4_address(address):
     assert ipv4(address)
+    assert not ipv6(address)
 
 
 @pytest.mark.parametrize(('address',), [

--- a/tests/test_ipv6.py
+++ b/tests/test_ipv6.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from validators import ipv6, ValidationFailure
+from validators import ipv4, ipv6, ValidationFailure
 
 
 @pytest.mark.parametrize(('address',), [
@@ -13,6 +13,7 @@ from validators import ipv6, ValidationFailure
 ])
 def test_returns_true_on_valid_ipv6_address(address):
     assert ipv6(address)
+    assert not ipv4(address)
 
 
 @pytest.mark.parametrize(('address',), [

--- a/validators/ip_address.py
+++ b/validators/ip_address.py
@@ -59,6 +59,8 @@ def ipv6(value):
     :param value: IP address string to validate
     """
     ipv6_groups = value.split(':')
+    if len(ipv6_groups) == 1:
+        return False
     ipv4_groups = ipv6_groups[-1].split('.')
 
     if len(ipv4_groups) > 1:


### PR DESCRIPTION
Fixes #58 

- Added tests to make sure valid IPv4 addresses return False on IPv6 and vice versa
- Made sure any address that lacks a : character returns False on IPv6.