### PR TITLE
Add Travis Testing for pypy3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7
+  - "3.7-dev"
   - pypy
   - pypy3
   - "pypy3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - 3.7
   - pypy
   - pypy3
+  - "pypy3.5"
 install:
   - pip install -e ".[test]"
 script:


### PR DESCRIPTION
"pypy3" is version 2.4.0 is feature compatible with Python 3.2.5.  (Python 3.2 itself reached its end of life on 2016-02-20).
"pypy3.5" should be feature compatible with Python 3.5.

Related to PR #61 .