### PR TITLE
Fix for TypeError in python 3.7 and pytest

### DIFF
--- a/validators/utils.py
+++ b/validators/utils.py
@@ -6,7 +6,7 @@ import six
 from decorator import decorator
 
 
-class ValidationFailure(object):
+class ValidationFailure(Exception):
     def __init__(self, func, args):
         self.func = func
         self.__dict__.update(args)


### PR DESCRIPTION
pytest with throw this error when running in version 3.7:
"TypeError: catching classes that do not inherit from BaseException is not allowed"
Changing the inheritance from object to Exception will fix this and is compatible back to version 2.7 and should cause no issues. 

This pytest sample test that will trigger the error in python 3.7:
   def test_init_with_bad_url(self):
        with pytest.raises(validators.ValidationFailure):
            assert True