### PR TITLE
Fix domain validator allowing numeric only TLDs

### DIFF
--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -29,7 +29,11 @@ def test_returns_true_on_valid_domain(value):
     '_example.com',
     'example_.com',
     'example',
-    'a......b.com'
+    'a......b.com',
+    'a.123',
+    '123.123',
+    '123.123.123',
+    '123.123.123.123'
 ])
 def test_returns_failed_validation_on_invalid_domain(value):
     assert isinstance(domain(value), ValidationFailure)

--- a/validators/domain.py
+++ b/validators/domain.py
@@ -6,7 +6,7 @@ pattern = re.compile(
     r'^(?:[a-z0-9]'  # First character of the domain
     r'(?:[a-z0-9-_]{0,61}[a-z0-9])?\.)'  # Sub domain + hostname
     r'+[a-z0-9][a-z0-9-_]{0,61}'  # First 61 characters of the gTLD
-    r'[a-z0-9]$'  # Last character of the gTLD
+    r'[a-z]$'  # Last character of the gTLD
 )
 
 


### PR DESCRIPTION
Updated regex to not allow numeric only TLDs

Fixes #123