### PR TITLE
Fix domain validation

### DIFF
--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -13,7 +13,9 @@ from validators import domain, ValidationFailure
     '3.cn',
     'a.cn',
     'sub1.sub2.sample.co.uk',
-    'somerandomexample.xn--fiqs8s'
+    'somerandomexample.xn--fiqs8s',
+    'kräuter.com',
+    'über.com'
 ])
 def test_returns_true_on_valid_domain(value):
     assert domain(value)
@@ -29,7 +31,11 @@ def test_returns_true_on_valid_domain(value):
     '_example.com',
     'example_.com',
     'example',
-    'a......b.com'
+    'a......b.com',
+    'a.123',
+    '123.123',
+    '123.123.123',
+    '123.123.123.123'
 ])
 def test_returns_failed_validation_on_invalid_domain(value):
     assert isinstance(domain(value), ValidationFailure)

--- a/validators/domain.py
+++ b/validators/domain.py
@@ -1,13 +1,29 @@
 import re
 
+import six
+
 from .utils import validator
+
+if six.PY3:
+    text_type = str
+    unicode = str
+else:
+    text_type = unicode
 
 pattern = re.compile(
     r'^(?:[a-z0-9]'  # First character of the domain
     r'(?:[a-z0-9-_]{0,61}[a-z0-9])?\.)'  # Sub domain + hostname
     r'+[a-z0-9][a-z0-9-_]{0,61}'  # First 61 characters of the gTLD
-    r'[a-z0-9]$'  # Last character of the gTLD
+    r'[a-z]$'  # Last character of the gTLD
 )
+
+
+def to_unicode(obj, charset='utf-8', errors='strict'):
+    if obj is None:
+        return None
+    if not isinstance(obj, bytes):
+        return text_type(obj)
+    return obj.decode(charset, errors)
 
 
 @validator
@@ -40,4 +56,7 @@ def domain(value):
 
     :param value: domain string to validate
     """
-    return pattern.match(value)
+    try:
+        return pattern.match(to_unicode(value).encode('idna').decode('ascii'))
+    except UnicodeError:
+        return False


### PR DESCRIPTION
- Updated regex to not allow numeric only TLDs (examples in tests)
- Allow for idna encoded domains and test for them (examples in tests)

Fixes #47
Fixes #123