### PR TITLE
Fix URL ip_last_octet regex

### DIFF
--- a/validators/url.py
+++ b/validators/url.py
@@ -3,7 +3,7 @@ import re
 from .utils import validator
 
 ip_middle_octet = r"(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5]))"
-ip_last_octet = r"(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))"
+ip_last_octet = r"(?:\.(?:0|[1-9]\d?|1\d\d|2[0-4]\d|25[0-5]))"
 
 regex = re.compile(  # noqa: W605
     r"^"


### PR DESCRIPTION
Allow URLs using IPs ending with 0 and 255, depending on the cidr they can be used.

Exemple:
- Network: 172.16.0.0/16
- Usable IP addresses: 172.16.0.1 -> 172.16.255.254