### PR TITLE
move from travis to github actions

### DIFF
--- a/.github/workflow/main.yml
+++ b/.github/workflow/main.yml
@@ -1,0 +1,41 @@
+name: GH
+
+on:
+  pull_request:
+    branches: '*'
+  push:
+    branches: 'master'
+    tags: '*'
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 8
+      matrix:
+        python-version: [3.4, 3.5, 3.6, 3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Pip cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements/*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: pip install -e ".[test]"
+
+    - name: Lint
+      run: | 
+        isort --recursive --diff validators tests && isort --recursive --check-only validators tests
+        flake8 validators tests
+      
+    - name: Test
+      run: py.test --doctest-glob="*.rst" --doctest-modules --ignore=setup.py


### PR DESCRIPTION
Github actions provide a lot of flexibility in terms of CI, we could possible move to Actions instead of travis
