### PR TITLE
Validate non-string UUID types

### DIFF
--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from uuid import UUID
 import pytest
 
 from validators import uuid, ValidationFailure
@@ -8,6 +9,13 @@ from validators import uuid, ValidationFailure
     ('2bc1c94f-0deb-43e9-92a1-4775189ec9f8',),
 ])
 def test_returns_true_on_valid_mac_address(value):
+    assert uuid(value)
+
+
+@pytest.mark.parametrize(('value',), [
+    (UUID('2bc1c94f-0deb-43e9-92a1-4775189ec9f8'),),
+])
+def test_returns_true_on_valid_uuid_object(value):
     assert uuid(value)
 
 

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -19,3 +19,13 @@ def test_returns_true_on_valid_mac_address(value):
 ])
 def test_returns_failed_validation_on_invalid_mac_address(value):
     assert isinstance(uuid(value), ValidationFailure)
+
+
+@pytest.mark.parametrize(('value',), [
+    (1,),
+    (1.0,),
+    (True,),
+    (None,),
+])
+def test_returns_failed_validation_on_invalid_types(value):
+    assert isinstance(uuid(value), ValidationFailure)

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from uuid import UUID
+
 import pytest
 
 from validators import uuid, ValidationFailure

--- a/validators/uuid.py
+++ b/validators/uuid.py
@@ -1,4 +1,6 @@
+from __future__ import absolute_import
 import re
+from uuid import UUID
 
 from .utils import validator
 
@@ -28,8 +30,10 @@ def uuid(value):
 
     .. versionadded:: 0.2
 
-    :param value: UUID string to validate
+    :param value: UUID value to validate
     """
+    if isinstance(value, UUID):
+        return True
     try:
         return pattern.match(value)
     except TypeError:

--- a/validators/uuid.py
+++ b/validators/uuid.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 import re
 from uuid import UUID
 

--- a/validators/uuid.py
+++ b/validators/uuid.py
@@ -30,4 +30,7 @@ def uuid(value):
 
     :param value: UUID string to validate
     """
-    return pattern.match(value)
+    try:
+        return pattern.match(value)
+    except TypeError:
+        return False


### PR DESCRIPTION
Right now, passing a type to `uuid` that cannot be pattern matched results in `TypeError: expected string or bytes-like object`.

This fixes that by catching any potential `TypeError` and returning `False` in those cases.