### PR TITLE
validators: drop six usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ extras_require = {
 }
 
 install_requires = [
-    'six>=1.4.0',
     'decorator>=3.4.0',
 ]
 

--- a/tests/test_validation_failure.py
+++ b/tests/test_validation_failure.py
@@ -1,5 +1,3 @@
-import six
-
 import validators
 
 obj_repr = (
@@ -19,7 +17,7 @@ class TestValidationFailure(object):
         assert obj_repr in repr(self.obj)
 
     def test_unicode(self):
-        assert obj_repr in six.text_type(self.obj)
+        assert obj_repr in str(self.obj)
 
     def test_arguments_as_properties(self):
         assert self.obj.value == 3

--- a/validators/domain.py
+++ b/validators/domain.py
@@ -1,14 +1,6 @@
 import re
 
-import six
-
 from .utils import validator
-
-if six.PY3:
-    text_type = str
-    unicode = str
-else:
-    text_type = unicode
 
 pattern = re.compile(
     r'^(?:[a-zA-Z0-9]'  # First character of the domain
@@ -22,7 +14,7 @@ def to_unicode(obj, charset='utf-8', errors='strict'):
     if obj is None:
         return None
     if not isinstance(obj, bytes):
-        return text_type(obj)
+        return str(obj)
     return obj.decode(charset, errors)
 
 

--- a/validators/truthy.py
+++ b/validators/truthy.py
@@ -1,5 +1,3 @@
-import six
-
 from .utils import validator
 
 
@@ -37,5 +35,5 @@ def truthy(value):
     """
     return (
         value and
-        (not isinstance(value, six.string_types) or value.strip())
+        (not isinstance(value, str) or value.strip())
     )

--- a/validators/utils.py
+++ b/validators/utils.py
@@ -2,7 +2,6 @@ import inspect
 import itertools
 from collections import OrderedDict
 
-import six
 from decorator import decorator
 
 
@@ -37,10 +36,7 @@ def func_args_as_dict(func, args, kwargs):
     Return given function's positional and key value arguments as an ordered
     dictionary.
     """
-    if six.PY2:
-        _getargspec = inspect.getargspec
-    else:
-        _getargspec = inspect.getfullargspec
+    _getargspec = inspect.getfullargspec
 
     arg_names = list(
         OrderedDict.fromkeys(
@@ -51,7 +47,7 @@ def func_args_as_dict(func, args, kwargs):
         )
     )
     return OrderedDict(
-        list(six.moves.zip(arg_names, args)) +
+        list(zip(arg_names, args)) +
         list(kwargs.items())
     )
 


### PR DESCRIPTION
As python 3.4 is required there's not need to keep six for Python 2
compat.