### PR TITLE
Minor fix for hostname with underscores

### DIFF
--- a/validators/url.py
+++ b/validators/url.py
@@ -69,7 +69,7 @@ regex = re.compile(  # noqa: W605
     r"(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])"
     r")\]|"
     # host name
-    r"(?:(?:(?:xn--)|[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9_?]-?)*"
+    r"(?:(?:(?:xn--)|[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9_]-?)*"
     r"[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]+)"
     # domain name
     r"(?:\.(?:(?:xn--)|[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]-?)*"

--- a/validators/url.py
+++ b/validators/url.py
@@ -69,7 +69,7 @@ regex = re.compile(  # noqa: W605
     r"(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])"
     r")\]|"
     # host name
-    r"(?:(?:(?:xn--)|[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]-?)*"
+    r"(?:(?:(?:xn--)|[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]-?_?)*"
     r"[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]+)"
     # domain name
     r"(?:\.(?:(?:xn--)|[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]-?)*"

--- a/validators/url.py
+++ b/validators/url.py
@@ -69,7 +69,7 @@ regex = re.compile(  # noqa: W605
     r"(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])"
     r")\]|"
     # host name
-    r"(?:(?:(?:xn--)|[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]-?_?)*"
+    r"(?:(?:(?:xn--)|[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9_?]-?)*"
     r"[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]+)"
     # domain name
     r"(?:\.(?:(?:xn--)|[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]-?)*"


### PR DESCRIPTION
Hello! I've noticed that I had some errors when getting a URL with a hostname that has an underscore, so I thought of finding and making some changes to the code such that URLs with an underscore in the hostname will now be valid, example:
https://_this_is_an.example.com

I was unable to test with the testing folder of the project, mainly because I don't really know how either because there is no documentation or I am looking in the wrong areas, or I lack experience with python testing with how this project is structured. I did use my own method of testing (using grep and the -P argument) and the results worked in the favor I was intending for, so hopefully it works in the code as well.

I was also inspired that this issue has already been hinted at but not fixed.

Closes #102 
Closes #180 
Maybe closes #38
And maybe something should happen to #179